### PR TITLE
Add support for multiple clusters in the same project

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To work around this, the app keeps a mapping of compute instance ID to Kubernete
 
 A second log router + pubsub topic exist to inform the app of new instances that belong to a Kubernetes cluster. On app startup, the compute API is queried to seed the mapping.
 
-![spot-interruption-exporter-gcp](https://github.com/thought-machine/spot-interruption-exporter/assets/11613073/3aac4b50-8ff3-49b2-9edd-cf60da294e98)
+![spot-interruption-exporter-gcp](https://github.com/thought-machine/spot-interruption-exporter/assets/11613073/f2b01b81-1d13-4a2d-8303-9c842b51b3f7)
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # spot-interruption-exporter
+
 Publishes a prometheus metric `interruption_events_total` that increments by 1 whenever a spot instance has been preempted.
 
 This is a very helpful metric, as it 
@@ -16,6 +17,7 @@ The app can be expanded to support other cloud providers, but currently is only 
 A single deployment of the infrastructure and app is intended to serve all Kubernetes clusters in a given project.
 
 ## How it works
+
 Spot preemption events are emitted as an audit log that contain the compute instance ID. These audit logs are forwarded to a pubsub topic via GCP Log Sink. The app then subscribes to this topic and handles the interruption event. 
 
 The audit log for instance preemption does not contain information about the Kubernetes cluster the instance may or may not have been associated with. Since the node is already deleted by the time the preemption event is received, the compute API cannot be queried for more information. 
@@ -44,6 +46,7 @@ prometheus:
 ## Deploying
 
 ### Infrastructure
+
 You'll need to deploy the required infrastructure before standing up the application.
 
 The infrastructure that the app depends for GCP on can be created via
@@ -58,6 +61,7 @@ $ terraform -chdir=infra/gcp destroy
 ```
 
 ### Kubernetes manifests
+
 `kustomize/` holds relevant kubernetes config files. You will likely want to overlay the base resources. For an example of how you might do this, see `kustomize/example-overlay`.
 
 ## Verifying

--- a/config.go
+++ b/config.go
@@ -5,21 +5,21 @@ import (
 	"os"
 )
 
-type GCPConfig struct {
-	PubSubSubscriptionName string `yaml:"subscription_name"`
-	Project                string `yaml:"project_name"`
-}
-
 type PrometheusConfig struct {
 	Path string
 	Port string
 }
 
+type PubSub struct {
+	InstanceCreationSubscriptionName     string `yaml:"instance_creation_subscription_name"`
+	InstanceInterruptionSubscriptionName string `yaml:"instance_interruption_subscription_name"`
+}
+
 type Config struct {
-	Provider    string    `yaml:"cloud_provider"`
-	ClusterName string    `yaml:"cluster_name"`
-	LogLevel    string    `yaml:"log_level"`
-	GCP         GCPConfig `yaml:"gcp"`
+	PubSub      PubSub `yaml:"pubsub"`
+	Project     string `yaml:"project_name"`
+	ClusterName string `yaml:"cluster_name"`
+	LogLevel    string `yaml:"log_level"`
 	Prometheus  PrometheusConfig
 }
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -13,12 +13,12 @@ import (
 	"time"
 )
 
-type InstanceInterruptionEvent struct {
+type instanceInterruptionEvent struct {
 	MessageID  string
 	ResourceID string
 }
 
-type InstanceCreationEvent struct {
+type instanceCreationEvent struct {
 	MessageID   string
 	ResourceID  string
 	ClusterName string
@@ -67,23 +67,23 @@ func HandleInterruptionEvents(interruptions chan *gcppubsub.Message, m cache.Cac
 	}
 }
 
-func messageToInstanceInterruptionEvent(m *gcppubsub.Message) (InstanceInterruptionEvent, error) {
+func messageToInstanceInterruptionEvent(m *gcppubsub.Message) (instanceInterruptionEvent, error) {
 	entry := auditdata.LogEntryData{}
 	err := protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(m.Data, &entry)
 	if err != nil {
-		return InstanceInterruptionEvent{}, err
+		return instanceInterruptionEvent{}, err
 	}
-	return InstanceInterruptionEvent{
+	return instanceInterruptionEvent{
 		MessageID:  m.ID,
 		ResourceID: entry.ProtoPayload.ResourceName,
 	}, nil
 }
 
-func messageToInstanceCreationEvent(m *gcppubsub.Message) (InstanceCreationEvent, error) {
+func messageToInstanceCreationEvent(m *gcppubsub.Message) (instanceCreationEvent, error) {
 	entry := auditdata.LogEntryData{}
 	err := protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(m.Data, &entry)
 	if err != nil {
-		return InstanceCreationEvent{}, err
+		return instanceCreationEvent{}, err
 	}
 	labels := entry.ProtoPayload.Request.GetFields()["labels"]
 	clusterName := "undefined"
@@ -95,7 +95,7 @@ func messageToInstanceCreationEvent(m *gcppubsub.Message) (InstanceCreationEvent
 			break
 		}
 	}
-	return InstanceCreationEvent{
+	return instanceCreationEvent{
 		MessageID:   m.ID,
 		ResourceID:  entry.ProtoPayload.ResourceName,
 		ClusterName: clusterName,

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -56,12 +56,12 @@ func HandleInterruptionEvents(interruptions chan *gcppubsub.Message, m cache.Cac
 		clusterName, ok := m.Get(e.ResourceID)
 		if !ok {
 			s.Warnf("failed to determine cluster the instance (%s) belongs to", e.ResourceID)
-			clusterName = "unspecified"
-		} else {
-			expireAfter := time.Second * 30
-			m.SetExpiration(e.ResourceID, expireAfter)
-			s.Debugf("%s will no longer be tracked after %s", e.ResourceID, expireAfter)
+			return
 		}
+		expireAfter := time.Second * 30
+		m.SetExpiration(e.ResourceID, expireAfter)
+		s.Debugf("%s will no longer be tracked after %s", e.ResourceID, expireAfter)
+
 		s.Info("interrupted")
 		metrics.IncreaseInterruptionEventCounter(clusterName)
 	}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,0 +1,104 @@
+// Package handlers contains functions for converting generic GCP PubSub messages to app-specific messages
+package handlers
+
+import (
+	gcppubsub "cloud.google.com/go/pubsub"
+	"github.com/googleapis/google-cloudevents-go/cloud/auditdata"
+	"github.com/thought-machine/spot-interruption-exporter/internal/cache"
+	"github.com/thought-machine/spot-interruption-exporter/internal/compute"
+	"github.com/thought-machine/spot-interruption-exporter/internal/metrics"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
+	"strings"
+	"time"
+)
+
+type InstanceInterruptionEvent struct {
+	MessageID  string
+	ResourceID string
+}
+
+type InstanceCreationEvent struct {
+	MessageID   string
+	ResourceID  string
+	ClusterName string
+}
+
+// HandleCreationEvents reads from additions and adds the instance ID and corresponding cluster to m
+func HandleCreationEvents(additions chan *gcppubsub.Message, m cache.Cache, l *zap.SugaredLogger) {
+	for addition := range additions {
+		a, err := messageToInstanceCreationEvent(addition)
+		if err != nil {
+			l.Warnf("failed to convert pubsub message to creation event: %s", err.Error())
+		}
+		s := l.With("message_id", a.MessageID, "resource_id", a.ResourceID, "kubernetes_cluster", a.ClusterName)
+		m.Insert(a.ResourceID, a.ClusterName)
+		s.Info("added")
+	}
+}
+
+// HandleInterruptionEvents reads from interruptions and increases the interruption event counter of metrics accordingly
+func HandleInterruptionEvents(interruptions chan *gcppubsub.Message, m cache.Cache, metrics metrics.Client, l *zap.SugaredLogger) {
+	messageCache := cache.NewCacheWithTTL(time.Minute * 10)
+	for interruption := range interruptions {
+		e, err := messageToInstanceInterruptionEvent(interruption)
+		if err != nil {
+			l.Warnf("failed to convert pubsub message to interruption event: %s", err.Error())
+			continue
+		}
+		s := l.With("message_id", e.MessageID, "resource_id", e.ResourceID)
+		// this ensures we do not handle a duplicate message in the event pubsub sends it more than once
+		if exists := messageCache.Exists(e.MessageID); exists {
+			s.Debug("handled duplicate message")
+			continue
+		}
+		messageCache.Insert(e.MessageID, "")
+		clusterName, ok := m.Get(e.ResourceID)
+		if !ok {
+			s.Warnf("failed to determine cluster the instance (%s) belongs to", e.ResourceID)
+			clusterName = "unspecified"
+		} else {
+			expireAfter := time.Second * 30
+			m.SetExpiration(e.ResourceID, expireAfter)
+			s.Debugf("%s will no longer be tracked after %s", e.ResourceID, expireAfter)
+		}
+		s.Info("interrupted")
+		metrics.IncreaseInterruptionEventCounter(clusterName)
+	}
+}
+
+func messageToInstanceInterruptionEvent(m *gcppubsub.Message) (InstanceInterruptionEvent, error) {
+	entry := auditdata.LogEntryData{}
+	err := protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(m.Data, &entry)
+	if err != nil {
+		return InstanceInterruptionEvent{}, err
+	}
+	return InstanceInterruptionEvent{
+		MessageID:  m.ID,
+		ResourceID: entry.ProtoPayload.ResourceName,
+	}, nil
+}
+
+func messageToInstanceCreationEvent(m *gcppubsub.Message) (InstanceCreationEvent, error) {
+	entry := auditdata.LogEntryData{}
+	err := protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(m.Data, &entry)
+	if err != nil {
+		return InstanceCreationEvent{}, err
+	}
+	labels := entry.ProtoPayload.Request.GetFields()["labels"]
+	clusterName := "undefined"
+	for _, v := range labels.GetListValue().Values {
+		label := v.GetStructValue().AsMap()
+		labelKey := label["key"].(string)
+		if strings.EqualFold(labelKey, compute.ClusterNameLabelKey) {
+			clusterName = label["value"].(string)
+			break
+		}
+	}
+	return InstanceCreationEvent{
+		MessageID:   m.ID,
+		ResourceID:  entry.ProtoPayload.ResourceName,
+		ClusterName: clusterName,
+	}, nil
+
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -51,6 +51,7 @@ func (suite *HandlersTestSuite) TestHandleInterruptionEvents() {
 	wg.Add(1)
 	go HandleInterruptionEvents(interruptions, instanceToClusterMappings, suite.mockMetrics, suite.l, wg)
 	interruptions <- mockInterruptionMessage
+	interruptions <- mockInterruptionMessage
 	close(interruptions)
 	wg.Wait()
 }

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -34,6 +34,7 @@ func (suite *HandlersTestSuite) SetupSuite() {
 	suite.NoError(err)
 	suite.l = l.Sugar()
 }
+
 func TestHandlersTestSuite(t *testing.T) {
 	suite.Run(t, new(HandlersTestSuite))
 }

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	gcppubsub "cloud.google.com/go/pubsub"
+	"github.com/stretchr/testify/suite"
+	"github.com/thought-machine/spot-interruption-exporter/internal/cache"
+	"github.com/thought-machine/spot-interruption-exporter/internal/handlers/test_data"
+	"github.com/thought-machine/spot-interruption-exporter/internal/metrics/mocks"
+	"go.uber.org/zap"
+	"testing"
+	"time"
+)
+
+type HandlersTestSuite struct {
+	suite.Suite
+	mockMetrics *mocks.Client
+	l           *zap.SugaredLogger
+}
+
+var (
+	mockInterruptionMessage = &gcppubsub.Message{
+		ID:   "12345",
+		Data: test_data.InterruptionEventJSONFile,
+	}
+	mockCreationMessage = &gcppubsub.Message{
+		ID:   "12345",
+		Data: test_data.CreationEventJSONFile,
+	}
+)
+
+func (suite *HandlersTestSuite) SetupSuite() {
+	suite.mockMetrics = mocks.NewClient(suite.T())
+	l, err := zap.NewDevelopment()
+	suite.NoError(err)
+	suite.l = l.Sugar()
+}
+func TestHandlersTestSuite(t *testing.T) {
+	suite.Run(t, new(HandlersTestSuite))
+}
+
+func (suite *HandlersTestSuite) TestHandleInterruptionEvents() {
+	suite.mockMetrics.EXPECT().IncreaseInterruptionEventCounter("fake-cluster").Times(1)
+	initialInstances := map[string]string{
+		"projects/mock-project/zones/europe-west1-c/instances/mock-instance-spot-3706-5b909138-nr65": "fake-cluster",
+	}
+	instanceToClusterMappings := cache.NewCacheWithTTLFrom(cache.NoExpiration, initialInstances)
+	interruptions := make(chan *gcppubsub.Message)
+	go HandleInterruptionEvents(interruptions, instanceToClusterMappings, suite.mockMetrics, suite.l)
+	interruptions <- mockInterruptionMessage
+	interruptions <- mockInterruptionMessage
+}
+
+func (suite *HandlersTestSuite) TestHandleCreationEvents() {
+	fakeClusterName := "fake-cluster"
+	fakeInstanceName := "fake-instance"
+	initialInstances := map[string]string{
+		fakeInstanceName: fakeClusterName,
+	}
+	instanceToClusterMappings := cache.NewCacheWithTTLFrom(cache.NoExpiration, initialInstances)
+	additions := make(chan *gcppubsub.Message)
+	go HandleCreationEvents(additions, instanceToClusterMappings, suite.l)
+	additions <- mockCreationMessage
+	resourceName := "projects/123456789/zones/europe-west1-c/instances/fake-resource"
+
+	suite.Eventually(func() bool {
+		cluster, ok := instanceToClusterMappings.Get(resourceName)
+		return ok && fakeClusterName == cluster
+	}, time.Second, time.Millisecond)
+
+	cluster, ok := instanceToClusterMappings.Get(fakeInstanceName)
+	suite.True(ok)
+	suite.Equal(fakeClusterName, cluster)
+}
+
+func (suite *HandlersTestSuite) TestMessageToInstanceInterruptionEvent() {
+	event, err := messageToInstanceInterruptionEvent(mockInterruptionMessage)
+	suite.NoError(err)
+	suite.Equal("projects/mock-project/zones/europe-west1-c/instances/mock-instance-spot-3706-5b909138-nr65", event.ResourceID)
+	suite.Equal("12345", event.MessageID)
+}
+
+func (suite *HandlersTestSuite) TestMessageToInstanceCreationEvent() {
+
+	event, err := messageToInstanceCreationEvent(mockCreationMessage)
+	suite.NoError(err)
+	suite.Equal("projects/123456789/zones/europe-west1-c/instances/fake-resource", event.ResourceID)
+	suite.Equal("fake-cluster", event.ClusterName)
+	suite.Equal("12345", event.MessageID)
+}

--- a/internal/handlers/test_data/creation-event.json
+++ b/internal/handlers/test_data/creation-event.json
@@ -1,0 +1,16 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.insert",
+    "resourceName": "projects/123456789/zones/europe-west1-c/instances/fake-resource",
+    "request": {
+      "labels": [
+        {
+          "key": "goog-k8s-cluster-name",
+          "value": "fake-cluster"
+        }
+      ]
+    }
+  }
+}

--- a/internal/handlers/test_data/embed.go
+++ b/internal/handlers/test_data/embed.go
@@ -1,0 +1,11 @@
+package test_data
+
+import (
+	_ "embed"
+)
+
+//go:embed creation-event.json
+var CreationEventJSONFile []byte
+
+//go:embed interruption-event.json
+var InterruptionEventJSONFile []byte

--- a/internal/handlers/test_data/interruption-event.json
+++ b/internal/handlers/test_data/interruption-event.json
@@ -1,0 +1,7 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "methodName": "compute.instances.preempted",
+    "resourceName": "projects/mock-project/zones/europe-west1-c/instances/mock-instance-spot-3706-5b909138-nr65"
+  }
+}

--- a/kustomize/config.yaml
+++ b/kustomize/config.yaml
@@ -1,8 +1,8 @@
-cloud_provider: gcp
-cluster_name: example-cluster
-gcp:
-  project_name: example-project
-  subscription_name: spot-interruption-exporter-subscription
+log_level: debug
+project_name: example-project
+pubsub:
+  instance_creation_subscription_name: sie-creation-subscription
+  instance_interruption_subscription_name: sie-interruption-subscription
 prometheus:
   port: 8090
   path: /metrics

--- a/kustomize/example-overlay/config.yaml
+++ b/kustomize/example-overlay/config.yaml
@@ -1,8 +1,7 @@
-cloud_provider: gcp
-cluster_name: development-us-west-2
-gcp:
-  project_name: dev
-  subscription_name: spot-interruption-exporter-subscription
+project_name: tm-gcp-emea-build-infra
+pubsub:
+  instance_creation_subscription_name: sie-creation-subscription
+  instance_interruption_subscription_name: sie-interruption-subscription
 prometheus:
   port: 1111
   path: /bespoke-metrics-path

--- a/main.go
+++ b/main.go
@@ -54,15 +54,15 @@ func main() {
 	additions := make(chan *gcppubsub.Message, 30)
 	instanceToClusterMappings := cache.NewCacheWithTTLFrom(cache.NoExpiration, initialInstances)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
 
 	go interruptionEvents.Receive(ctx, interruptions)
 	go creationEvents.Receive(ctx, additions)
 	log.Info("listening for instance creation & interruption events")
 
-	go handlers.HandleInterruptionEvents(interruptions, instanceToClusterMappings, m, log)
-	go handlers.HandleCreationEvents(additions, instanceToClusterMappings, log)
+	go handlers.HandleInterruptionEvents(interruptions, instanceToClusterMappings, m, log, wg)
+	go handlers.HandleCreationEvents(additions, instanceToClusterMappings, log, wg)
 	log.Info("handlers started for instance creation & interruption events")
 	wg.Wait()
 }

--- a/main.go
+++ b/main.go
@@ -1,30 +1,19 @@
-// Package main listens for interruption events from the specified Notifier,
+// Package main listens for interruption events from the specified InterruptionNotifier,
 // incrementing a counter every time an event is received
 package main
 
 import (
+	gcppubsub "cloud.google.com/go/pubsub"
 	"context"
 	"fmt"
-	"go.uber.org/zap"
-	"log"
-	"net/http"
-	"os"
-	"strings"
-	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/thought-machine/spot-interruption-exporter/internal/cache"
+	"github.com/thought-machine/spot-interruption-exporter/internal/compute"
 	"github.com/thought-machine/spot-interruption-exporter/internal/events"
-)
-
-var (
-	interruptionEvents = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "interruption_events_total",
-		Help: "The total number of spot interruptions for a given cluster",
-	}, []string{"kubernetes_cluster"})
+	"github.com/thought-machine/spot-interruption-exporter/internal/handlers"
+	"github.com/thought-machine/spot-interruption-exporter/internal/metrics"
+	"go.uber.org/zap"
+	"os"
+	"sync"
 )
 
 func main() {
@@ -37,6 +26,63 @@ func main() {
 		panic(err)
 	}
 
+	log := configureLogger(cfg)
+	m := metrics.NewClient(cfg.Prometheus.Path, cfg.Prometheus.Port, log)
+	go m.RegisterHTTPHandler()
+
+	interruptionEvents, err := createSubscriptionClient(ctx, log, cfg.Project, cfg.PubSub.InstanceInterruptionSubscriptionName)
+	if err != nil {
+		log.Fatal("failed to init instance interruption subscription: %s", err.Error())
+	}
+
+	creationEvents, err := createSubscriptionClient(ctx, log, cfg.Project, cfg.PubSub.InstanceCreationSubscriptionName)
+	if err != nil {
+		log.Fatal("failed to init instance creation subscription: %s", err.Error())
+	}
+
+	computeClient, err := createComputeClient(ctx, log, cfg)
+	if err != nil {
+		log.Fatal("failed to init compute client")
+	}
+
+	initialInstances, err := computeClient.ListInstancesBelongingToKubernetesCluster(ctx)
+	if err != nil {
+		log.Fatal("failed to determine initial instances belonging to kubernetes clusters: %s", err.Error())
+	}
+
+	interruptions := make(chan *gcppubsub.Message, 30)
+	additions := make(chan *gcppubsub.Message, 30)
+	instanceToClusterMappings := cache.NewCacheWithTTLFrom(cache.NoExpiration, initialInstances)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go interruptionEvents.Receive(ctx, interruptions)
+	go creationEvents.Receive(ctx, additions)
+	log.Info("listening for instance creation & interruption events")
+
+	go handlers.HandleInterruptionEvents(interruptions, instanceToClusterMappings, m, log)
+	go handlers.HandleCreationEvents(additions, instanceToClusterMappings, log)
+	log.Info("handlers started for instance creation & interruption events")
+	wg.Wait()
+}
+
+func createComputeClient(ctx context.Context, log *zap.SugaredLogger, cfg Config) (compute.Client, error) {
+	return compute.NewClient(ctx, compute.NewClientInput{
+		Logger:    log,
+		ProjectID: cfg.Project,
+	})
+}
+
+func createSubscriptionClient(ctx context.Context, log *zap.SugaredLogger, projectID, subscriptionName string) (events.Subscription, error) {
+	return events.NewPubSubNotifier(ctx, &events.NewPubSubNotifierInput{
+		Logger:           log,
+		ProjectID:        projectID,
+		SubscriptionName: subscriptionName,
+	})
+}
+
+func configureLogger(cfg Config) *zap.SugaredLogger {
 	loggerConfig := zap.NewProductionConfig()
 	if err := configureLogLevel(&loggerConfig, cfg.LogLevel); err != nil {
 		panic(fmt.Sprintf("failed to parse log level: %s", err.Error()))
@@ -44,51 +90,10 @@ func main() {
 	loggerConfig.EncoderConfig.TimeKey = "time"
 	logger, err := loggerConfig.Build()
 	if err != nil {
-		log.Fatalf("failed to initialize zap logger: %v", err)
+		panic(fmt.Sprintf("failed to initialize zap logger: %v", err))
 	}
-	sugar := logger.Sugar()
-	http.Handle(cfg.Prometheus.Path, promhttp.Handler())
-	go func() {
-		sugar.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", cfg.Prometheus.Port), nil))
-	}()
-
-	n, err := createCSPNotifier(ctx, sugar, cfg)
-	if err != nil {
-		sugar.Fatal("failed to init cloud-provider client: %s", err.Error())
-	}
-
-	e := make(chan events.InterruptionEvent)
-	go n.Receive(ctx, e)
-
-	c := cache.NewCacheWithTTL(time.Minute * 10)
-	for event := range e {
-		s := sugar.With("message_id", event.MessageID, "resource_id", event.ResourceID)
-		// this ensures we do not handle a duplicate message in the event pubsub sends it more than once
-		if exists := c.Exists(event.MessageID); exists {
-			s.Debug("handled duplicate message")
-			continue
-		}
-		c.Insert(event.MessageID)
-		interruptionEvents.WithLabelValues(cfg.ClusterName).Inc()
-		s.Info("interrupted")
-	}
-}
-
-func createCSPNotifier(ctx context.Context, log *zap.SugaredLogger, cfg Config) (events.Notifier, error) {
-	switch {
-	case strings.EqualFold(cfg.Provider, "gcp"):
-		n, err := events.NewPubSubNotifier(ctx, &events.NewPubSubNotifierInput{
-			Logger:           log,
-			ProjectID:        cfg.GCP.Project,
-			SubscriptionName: cfg.GCP.PubSubSubscriptionName,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create GCP client: %w", err)
-		}
-		return n, nil
-	default:
-		return nil, fmt.Errorf("unknown or unsupported cloud provider: %s", cfg.Provider)
-	}
+	log := logger.Sugar()
+	return log
 }
 
 func configureLogLevel(lCfg *zap.Config, logLevel string) error {


### PR DESCRIPTION
## Summary
This is the bulk of the change to support multiple clusters within the same GCP project. The biggest issue is that the audit logs for preemption events contain no information about the Kubernetes cluster the instance belonged to. Because of this, the app needs to maintain a mapping of instance to kubernetes cluster, so that when a preemption event is received, the appropriate value for the label `kubernetes_cluster` can be set on the preemption metric.

As instances come and go quite frequently, it's better to have instance creation events available than it is to poll the compute API repeatedly. So the same setup (log sink + pubsub) that is used for preemption events is used for creation events. One query to the compute API is made on app startup to establish the state of the world before relying on events to do so.

There are two main handlers, one to handle instance creation events and one to handle instance preemption events.

The instance creation handler simply updates a concurrency-safe cache as instance creation events come in. The instance preemption handler then references that cache to determine which cluster an instance belonged to. Once the preemption event is handled, the mapping for that instance is removed from the cache after ~30 seconds.

The mapping looks like
```
"projects/mock-project/zones/europe-west1-c/instances/mock-instance-spot-3706-5b909138-nr65" => "fake-cluster"
```

The log sink is configured in such a way that only instances with the label `goog-k8s-cluster-name` are forwarded to the app. This is the way we determine which instances belong to a Kubernetes cluster. Unfortunately all preemption events are forwarded, regardless if they belong to a Kubernetes cluster.

## Tests
It's rather hard to show the testing I've done outside unit tests given the amount of moving parts here. Ideally we could setup a few E2E tests but probably more effort than it's worth.

A few of the scenarios I've run through
1. Send interruption event for instance that does not exist
2. Send interruption event for instance that already exists at the time the app boots up (ie. relying on compute API query)
3. Send creation event for instance
4. Send creation event for instance followed by interruption event for that same instance