### PR TITLE
Make config specific to GCP

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,21 +5,21 @@ import (
 	"os"
 )
 
-type GCPConfig struct {
-	PubSubSubscriptionName string `yaml:"subscription_name"`
-	Project                string `yaml:"project_name"`
-}
-
 type PrometheusConfig struct {
 	Path string
 	Port string
 }
 
+type PubSub struct {
+	InstanceCreationSubscriptionName     string `yaml:"instance_creation_subscription_name"`
+	InstanceInterruptionSubscriptionName string `yaml:"instance_interruption_subscription_name"`
+}
+
 type Config struct {
-	Provider    string    `yaml:"cloud_provider"`
-	ClusterName string    `yaml:"cluster_name"`
-	LogLevel    string    `yaml:"log_level"`
-	GCP         GCPConfig `yaml:"gcp"`
+	PubSub      PubSub `yaml:"pubsub"`
+	Project     string `yaml:"project_name"`
+	ClusterName string `yaml:"cluster_name"`
+	LogLevel    string `yaml:"log_level"`
 	Prometheus  PrometheusConfig
 }
 

--- a/kustomize/config.yaml
+++ b/kustomize/config.yaml
@@ -1,8 +1,8 @@
-cloud_provider: gcp
-cluster_name: example-cluster
-gcp:
-  project_name: example-project
-  subscription_name: spot-interruption-exporter-subscription
+log_level: debug
+project_name: example-project
+pubsub:
+  instance_creation_subscription_name: sie-creation-subscription
+  instance_interruption_subscription_name: sie-interruption-subscription
 prometheus:
   port: 8090
   path: /metrics

--- a/kustomize/example-overlay/config.yaml
+++ b/kustomize/example-overlay/config.yaml
@@ -1,8 +1,7 @@
-cloud_provider: gcp
-cluster_name: development-us-west-2
-gcp:
-  project_name: dev
-  subscription_name: spot-interruption-exporter-subscription
+project_name: tm-gcp-emea-build-infra
+pubsub:
+  instance_creation_subscription_name: sie-creation-subscription
+  instance_interruption_subscription_name: sie-interruption-subscription
 prometheus:
   port: 1111
   path: /bespoke-metrics-path


### PR DESCRIPTION
As evident in a few of the other pull requests, I've removed references trying to make this cloud-provider agnostic. Trying to keep things cloud-provider agnostic is mostly a guessing game of what this would look like in another cloud-provider. That's quite hard to say and feels like a preoptimisation