### PR TITLE
Use GCP selflink for tracking instances throughout

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -100,17 +100,19 @@ func messageToInstanceCreationEvent(m *gcppubsub.Message) (instanceCreationEvent
 		return instanceCreationEvent{}, fmt.Errorf("expected labels not found on instance creation request, operation ID: %s", entry.Operation.Id)
 	}
 
-	clusterName := "unknown"
+	var clusterName string
+	var found bool
 	for _, v := range labels.GetListValue().Values {
 		label := v.GetStructValue().AsMap()
 		labelKey := label["key"].(string)
 		if strings.EqualFold(labelKey, compute.ClusterNameLabelKey) {
 			clusterName = label["value"].(string)
+			found = true
 			break
 		}
 	}
 
-	if clusterName == "unknown" {
+	if !found {
 		return instanceCreationEvent{}, fmt.Errorf("expected cluster label %s not found on instance creation request, operation ID: %s", compute.ClusterNameLabelKey, entry.Operation.Id)
 	}
 

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -71,7 +71,7 @@ func (suite *HandlersTestSuite) TestHandleCreationEvents() {
 	additions <- mockCreationMessage
 	close(additions)
 	wg.Wait()
-	resourceName := "projects/123456789/zones/europe-west1-c/instances/fake-resource"
+	resourceName := "projects/mock-project/zones/europe-west1-c/instances/fake-resource"
 
 	cluster, err := instanceToClusterMappings.Get(resourceName)
 	suite.NoError(err)
@@ -92,7 +92,7 @@ func (suite *HandlersTestSuite) TestMessageToInstanceInterruptionEvent() {
 func (suite *HandlersTestSuite) TestMessageToInstanceCreationEvent() {
 	event, err := messageToInstanceCreationEvent(mockCreationMessage)
 	suite.NoError(err)
-	suite.Equal("projects/123456789/zones/europe-west1-c/instances/fake-resource", event.ResourceID)
+	suite.Equal("projects/mock-project/zones/europe-west1-c/instances/fake-resource", event.ResourceID)
 	suite.Equal("fake-cluster", event.ClusterName)
 	suite.Equal("12345", event.MessageID)
 }

--- a/internal/handlers/test_data/creation-event.json
+++ b/internal/handlers/test_data/creation-event.json
@@ -3,7 +3,6 @@
     "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
     "serviceName": "compute.googleapis.com",
     "methodName": "v1.compute.instances.insert",
-    "resourceName": "projects/123456789/zones/europe-west1-c/instances/fake-resource",
     "request": {
       "labels": [
         {
@@ -11,6 +10,15 @@
           "value": "fake-cluster"
         }
       ]
+    },
+    "response": {
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/mock-project/zones/europe-west1-c/instances/fake-resource",
+      "@type": "type.googleapis.com/operation"
     }
+  },
+  "operation": {
+    "id": "operation-1704446377001-60e2f58d702e9-78fe21e1-13682ff1",
+    "producer": "compute.googleapis.com",
+    "first": true
   }
 }


### PR DESCRIPTION
When the compute API is first queried, the self link is used to form a resource ID that is put in the cache. After formatting, that looks like 

```
projects/mock-project/zones/europe-west1-c/instances/fake-resource
```

but when creation events are received, the resource name uses the project ID instead of the number, which looks like

```
projects/12345678/zones/europe-west1-c/instances/fake-resource
```

This leads to two types of resource IDs being stored in the cache. To fix this, compute resource IDs are stored in the form

```
projects/mock-project/zones/europe-west1-c/instances/fake-resource
```

which is formed from the self link. 

Additionally, preemption events do not contain a self link, but the format of the resource ID matches what we stored in the cache.

This also fixes a small bug where an instance would be tracked even if parsing the pubsub message failed