### PR TITLE
change label key for kubernetes_cluster to avoid confusion

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,7 +16,7 @@ var (
 	interruptionEvents = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "interruption_events_total",
 		Help: "The total number of spot interruptions for a given cluster",
-	}, []string{"kubernetes_cluster"})
+	}, []string{"target_kubernetes_cluster"})
 )
 
 // Client provides methods for modifying metrics


### PR DESCRIPTION
Internally `kubernetes_cluster` represents the kubernetes cluster the metric was scraped from. To avoid confusion, the label has been renamed to `target_kubernetes_cluster` which represents the cluster the preemption occurred on.